### PR TITLE
BUGFIX: Use FileBackend per default for lifetime support

### DIFF
--- a/Configuration/Caches.yaml
+++ b/Configuration/Caches.yaml
@@ -1,5 +1,5 @@
 Netlogix_GoogleSearchConsoleInspector_Responses:
   frontend: Neos\Cache\Frontend\VariableFrontend
-  persistent: true
+  backend: Neos\Cache\Backend\FileBackend
   backendOptions:
     defaultLifetime: 86400


### PR DESCRIPTION
By default, Flow will use a SimpleFileBackend, which does not support lifetime of entries.